### PR TITLE
Allow async component shutdown

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/postgres-gateway "1.4.0"
+(defproject clanhr/postgres-gateway "1.5.0"
   :description "ClanHR postgres-gateway"
   :url "https://github.com/clanhr/postgres-gateway"
 


### PR DESCRIPTION
The new pg async driver will wait for the connection to shutdown, and
this makes testes very slow. With this flag, the semantics stays the
same, on the test components we just need to make `async-close?` true.

Ref: https://github.com/alaisi/postgres.async/issues/17#issuecomment-161788446
