### PR TITLE
Allow query as a stream

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -13,6 +13,7 @@
                  [org.clojure/clojure "1.7.0-RC1"]
                  [org.clojure/java.jdbc "0.4.2"]
                  [alaisi/postgres.async "0.6.0"]
+                 [postgresql "9.3-1102.jdbc41"]
                  [cheshire "5.5.0"]
                  [com.stuartsierra/component "0.3.1"]
                  [clanhr/result "0.10.3"]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/postgres-gateway "1.5.2"
+(defproject clanhr/postgres-gateway "1.6.0"
   :description "ClanHR postgres-gateway"
   :url "https://github.com/clanhr/postgres-gateway"
 
@@ -17,7 +17,7 @@
                  [cheshire "5.5.0"]
                  [com.stuartsierra/component "0.3.1"]
                  [clanhr/result "0.10.3"]
-                 [clanhr/analytics "1.5.0"]]
+                 [clanhr/analytics "1.6.0"]]
 
   :plugins [[lein-environ "1.0.0"]
             [lein-ancient "0.6.5"]]

--- a/src/clanhr/postgres_gateway/config.clj
+++ b/src/clanhr/postgres_gateway/config.clj
@@ -42,6 +42,17 @@
            :password (env :pg-password "")
            :pool-size 1}))
 
+(defn db-config-map
+  "Gets the current used db config map"
+  ([]
+   (db-config-map nil))
+  ([config]
+   (let [base (resolve-db-config config)]
+     (assoc base :host (:hostname base)
+                 :dbname (:database base)
+                 :user (:username base)
+                 :dbtype "postgresql"))))
+
 (defn create-connection
   "Creates a new connection pool"
   ([] (create-connection nil))

--- a/src/clanhr/postgres_gateway/query_stream.clj
+++ b/src/clanhr/postgres_gateway/query_stream.clj
@@ -11,7 +11,7 @@
 
 (defn run
   "Opens a stream to a db query and returns a channel that will receive
-  batches of roes"
+  all the rows, one by one"
   ([sql]
    (run sql nil))
   ([sql config]

--- a/src/clanhr/postgres_gateway/query_stream.clj
+++ b/src/clanhr/postgres_gateway/query_stream.clj
@@ -23,7 +23,6 @@
     (future
       (j/query db-connection
                [statement]
-               :row-fn (fn [row]
-                         (>!! ch row)))
+               :row-fn (fn [row] (>!! ch row)))
       (close! ch))
     ch))

--- a/src/clanhr/postgres_gateway/query_stream.clj
+++ b/src/clanhr/postgres_gateway/query_stream.clj
@@ -3,6 +3,7 @@
   (require [postgres.async :refer :all]
            [cheshire.core :as json]
            [clojure.core.async :refer [go <!! >!! chan close!]]
+           [clanhr.postgres-gateway.config :as config]
            [clanhr.analytics.errors :as errors]
            [clojure.java.jdbc :as j]
            [environ.core :refer [env]]
@@ -12,7 +13,7 @@
   "Opens a stream to a db query and returns a channel that will receive
   batches of roes"
   [sql]
-  (let [db-spec "postgresql://192.168.59.103:5432/postgres?user=postgres&password=wasabi"
+  (let [db-spec (config/db-config-map)
         ch (chan 10)
         fetch-size 1000
         db-connection (doto ( j/get-connection db-spec) (.setAutoCommit true))

--- a/src/clanhr/postgres_gateway/query_stream.clj
+++ b/src/clanhr/postgres_gateway/query_stream.clj
@@ -1,0 +1,29 @@
+(ns clanhr.postgres-gateway.query-stream
+  "Reads a query as a stream of data"
+  (require [postgres.async :refer :all]
+           [cheshire.core :as json]
+           [clojure.core.async :refer [go <!! >!! chan close!]]
+           [clanhr.analytics.errors :as errors]
+           [clojure.java.jdbc :as j]
+           [environ.core :refer [env]]
+           [result.core :as result]))
+
+(defn run
+  "Opens a stream to a db query and returns a channel that will receive
+  batches of roes"
+  [sql]
+  (let [db-spec "postgresql://192.168.59.103:5432/postgres?user=postgres&password=wasabi"
+        ch (chan 10)
+        fetch-size 1000
+        db-connection (doto ( j/get-connection db-spec) (.setAutoCommit true))
+        statement (j/prepare-statement db-connection
+                                       sql
+                                       :fetch-size fetch-size
+                                       :concurrency :read-only)]
+    (future
+      (j/query db-connection
+               [statement]
+               :row-fn (fn [row]
+                         (>!! ch row)))
+      (close! ch))
+    ch))

--- a/src/clanhr/postgres_gateway/query_stream.clj
+++ b/src/clanhr/postgres_gateway/query_stream.clj
@@ -12,18 +12,20 @@
 (defn run
   "Opens a stream to a db query and returns a channel that will receive
   batches of roes"
-  [sql]
-  (let [db-spec (config/db-config-map)
-        ch (chan 10)
-        fetch-size 1000
-        db-connection (doto ( j/get-connection db-spec) (.setAutoCommit true))
-        statement (j/prepare-statement db-connection
-                                       sql
-                                       :fetch-size fetch-size
-                                       :concurrency :read-only)]
-    (future
-      (j/query db-connection
-               [statement]
-               :row-fn (fn [row] (>!! ch row)))
-      (close! ch))
-    ch))
+  ([sql]
+   (run sql nil))
+  ([sql config]
+   (let [db-spec (config/db-config-map config)
+         ch (chan 10)
+         fetch-size 1000
+         db-connection (doto ( j/get-connection db-spec) (.setAutoCommit true))
+         statement (j/prepare-statement db-connection
+                                        sql
+                                        :fetch-size fetch-size
+                                        :concurrency :read-only)]
+     (future
+       (j/query db-connection
+                [statement]
+                :row-fn (fn [row] (>!! ch row)))
+       (close! ch))
+     ch)))

--- a/test/clanhr/postgres_gateway/query_stream_test.clj
+++ b/test/clanhr/postgres_gateway/query_stream_test.clj
@@ -1,0 +1,48 @@
+(ns clanhr.postgres-gateway.query-stream-test
+  (:require [clojure.test :refer :all]
+            [clojure.core.async :refer [<!! go]]
+            [clanhr.postgres-gateway.core :as core]
+            [clj-time.core :as t]
+            [clanhr.postgres-gateway.config :as config]
+            [clanhr.postgres-gateway.query-stream :as query-stream]
+            [clanhr.postgres-gateway.component :as pg-component]
+            [postgres.async :refer :all]
+            [environ.core :refer [env]]
+            [result.core :as result]
+            [com.stuartsierra.component :as component]))
+
+(def ^:private ^:dynamic *db*)
+(def table "postgres_gateway_stream_tests")
+
+(defn- wait [channel]
+  (let [r (<!! channel)]
+    (if (instance? Throwable r)
+      (throw r))
+    r))
+
+(defn- create-tables [db]
+  (wait (execute! db ["CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";"]))
+  (wait (execute! db [(str "drop table if exists " table)]))
+  (wait (execute! db [(str "create table " table " (
+                           id uuid primary key default uuid_generate_v4(),
+                           model jsonb,
+                           email varchar(200),
+                           updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP)")])))
+
+(defn- db-fixture [f]
+  (binding [*db* (config/get-connection)]
+    (create-tables *db*)
+    (f)))
+
+(use-fixtures :each db-fixture)
+
+(deftest empty-stream
+  (let [ch (query-stream/run (str "select * from " table " where email = 'waza'"))
+        data (wait ch)]
+    (is (nil? data))))
+
+(deftest get-1-result-stream
+  (core/save-data! {:email "suricata@clanhr.com"} {:table table})
+  (let [ch (query-stream/run (str "select * from " table))
+        batch (wait ch)]
+    (is (not (nil? batch)))))


### PR DESCRIPTION
Given a query, an async chanel will be returned and all the rows will be put
on the channel. When no more rows are available, the chanel will be closed.

clanhr/mothership#529
