### PR TITLE
Update prepare-statement call

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/postgres-gateway "1.7.0"
+(defproject clanhr/postgres-gateway "1.7.1"
   :description "ClanHR postgres-gateway"
   :url "https://github.com/clanhr/postgres-gateway"
 

--- a/src/clanhr/postgres_gateway/query_stream.clj
+++ b/src/clanhr/postgres_gateway/query_stream.clj
@@ -14,8 +14,8 @@
   [db-connection sql fetch-size]
   (j/prepare-statement db-connection
                        sql
-                       :fetch-size fetch-size
-                       :concurrency :read-only))
+                       {:fetch-size fetch-size
+                        :concurrency :read-only}))
 
 (defn- create-statement
   "Creates a preared statement"


### PR DESCRIPTION
Motivation:

The new jdbc version deprecates unrolled arguments.

Modifications:

Transform the unrolled arguments in a map.

Result:

Deprecation warnings cease to exist.
