### PR TITLE
Remove shared deps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/postgres-gateway "1.7.1"
+(defproject clanhr/postgres-gateway "1.7.3"
   :description "ClanHR postgres-gateway"
   :url "https://github.com/clanhr/postgres-gateway"
 
@@ -9,16 +9,19 @@
 
   :min-lein-version "2.5.0"
 
-  :dependencies.edn "https://raw.githubusercontent.com/clanhr/dependencies/master/dependencies.edn"
 
-  :dependency-sets [:clojure :common :clanhr]
-
-  :dependencies [[org.clojure/java.jdbc "0.5.8"]
+  :dependencies [[environ "1.0.2"]
+                 [org.clojure/clojure "1.8.0"]
+                 [org.clojure/java.jdbc "0.5.8"]
                  [alaisi/postgres.async "0.6.0" :exclusions [[io.netty/netty-handler]]]
+                 [postgresql "9.3-1102.jdbc41"]
+                 [cheshire "5.6.1"]
+                 [com.stuartsierra/component "0.3.1"]
+                 [clanhr/result "0.11.0"]
+                 [clanhr/analytics "1.9.0"]
                  [postgresql "9.3-1102.jdbc41"]]
 
-  :plugins [[clanhr/shared-deps "0.2.6"]
-            [lein-environ "1.0.0"]
+  :plugins [[lein-environ "1.0.2"]
             [lein-ancient "0.6.5"]]
 
   :source-paths ["src"]


### PR DESCRIPTION
After adding the shared deps, the project became very slow on lein, and heroku
could not get it from clojars. I'm still trying to understand it. Meanwhile,
this reverts d2cef04bb82a57445cf3ae237c6f08a74dfd4eb0
