### PR TITLE
Fix rollback issues

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/postgres-gateway "1.7.3"
+(defproject clanhr/postgres-gateway "1.7.4"
   :description "ClanHR postgres-gateway"
   :url "https://github.com/clanhr/postgres-gateway"
 

--- a/project.clj
+++ b/project.clj
@@ -17,6 +17,7 @@
                  [postgresql "9.3-1102.jdbc41"]
                  [cheshire "5.6.1"]
                  [com.stuartsierra/component "0.3.1"]
+                 [org.slf4j/slf4j-nop "1.7.12"]
                  [clanhr/result "0.11.0"]
                  [clanhr/analytics "1.9.0"]
                  [postgresql "9.3-1102.jdbc41"]]

--- a/src/clanhr/postgres_gateway/config.clj
+++ b/src/clanhr/postgres_gateway/config.clj
@@ -100,7 +100,10 @@
 (defn rollback
   [config]
   (let [conn (get-connection config)]
-    (rollback! conn)))
+    (try
+      (rollback! conn)
+      (catch Exception e
+        (go (errors/exception e))))))
 
 (defn with-transaction!
   "Returns a context in a transaction"
@@ -139,4 +142,3 @@
         (catch Exception e
           (<! (rollback-transaction! context))
           (errors/exception e))))))
-

--- a/src/clanhr/postgres_gateway/config.clj
+++ b/src/clanhr/postgres_gateway/config.clj
@@ -67,7 +67,7 @@
 (defn on-shutdown
   "Shuts down the global connection"
   []
-  (println "Shutdown postgres-gateway...")
+  (println "Shutdown global postgres-gateway...")
   (when-let [conn @db-pool]
     (close-connection! conn)))
 
@@ -84,6 +84,7 @@
                         (if pool
                            pool
                            (do
+                             (println "Starting global postgres-gateway...")
                              (.addShutdownHook (Runtime/getRuntime) (Thread. on-shutdown))
                              (create-connection config))))))))
 
@@ -109,12 +110,18 @@
   "Returns a context in a transaction"
   [context]
   (go
-    (let [conn (-> context :pg-conn)
-          transaction-conn (<! (begin conn))]
-      (assoc context :pg-conn (reify
-                                connection-provider/ConnectionProvider
-                                (get-connection [this]
-                                  transaction-conn))))))
+    (let [conn (-> context :pg-conn)]
+      (if (nil? conn)
+        (errors/exception (ex-info "Missing :pg-conn at the system/context" {:success false}))
+        (let [transaction-conn (<! (begin conn))]
+          (if (instance? Throwable transaction-conn)
+            (errors/exception transaction-conn)
+            (-> context
+                (assoc :pg-conn (reify
+                                  connection-provider/ConnectionProvider
+                                  (get-connection [this]
+                                    transaction-conn)))
+                result/success)))))))
 
 (defn commit-transaction!
   "Commits the transaction on the context"
@@ -132,13 +139,15 @@
   [context f]
   (go
     (let [context (<! (with-transaction! context))]
-      (try
-        (let [result (<! (f context))]
-          (if (result/succeeded? result)
-            (do (<! (commit-transaction! context))
-                result)
-            (do (<! (rollback-transaction! context))
-                result)))
-        (catch Exception e
-          (<! (rollback-transaction! context))
-          (errors/exception e))))))
+      (if (result/failed? context)
+        context
+        (try
+          (let [result (<! (f context))]
+            (if (result/succeeded? result)
+              (do (<! (commit-transaction! context))
+                  result)
+              (do (<! (rollback-transaction! context))
+                  result)))
+          (catch Exception e
+            (<! (rollback-transaction! context))
+            (errors/exception e)))))))

--- a/src/clanhr/postgres_gateway/query_stream.clj
+++ b/src/clanhr/postgres_gateway/query_stream.clj
@@ -37,12 +37,11 @@
          fetch-size 1000
          db-connection (doto ( j/get-connection db-spec) (.setAutoCommit true))
          statement (create-statement db-connection sql fetch-size)]
-     (println (count statement) statement)
      (future
        (try
          (j/query db-connection
                   statement
-                  :row-fn (fn [row] (>!! ch row)))
+                  {:row-fn (fn [row] (>!! ch row))})
          (close! ch)
          (catch Exception e
            (>!! ch e)

--- a/test/clanhr/postgres_gateway/query_stream_test.clj
+++ b/test/clanhr/postgres_gateway/query_stream_test.clj
@@ -51,7 +51,6 @@
   (core/save-data! {:email "suricata@clanhr.com"} {:table table})
   (let [ch (query-stream/run [(str "select * from " table " where email=?") "suricata@clanhr.com"])
         batch (wait ch)]
-    (println batch)
     (is (not (nil? batch)))))
 
 (defn- take-all


### PR DESCRIPTION
Motivation:

We had several issues with the rollback:
- Clients of `transaction-run!` were expecting a result channel, but if
  we had an error, we'd return a result
- If the rollback failed (and it does by what apperars to be a bug on
  the driver), no result or channel was returned, but an exception was
  raised

Modifications:

The `rollback` fn now has an inner try-catch. If the call succeeds, a
new channel will be returned. If the call fails (and that was our
problem), the exception is catched, and wrapped by a channel with the
result. It will also be logged.

So this means that we can have a rollback that failes for some reason,
and we return a result. Those errors will be catalogued and should be
verified one by one.

On this scenario we had a problem where the socket was closed and we
created an issue with the driver.
