### PR TITLE
Fix DATE loading from the DB

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/postgres-gateway "1.8.0"
+(defproject clanhr/postgres-gateway "1.8.1"
   :description "ClanHR postgres-gateway"
   :url "https://github.com/clanhr/postgres-gateway"
 

--- a/src/clanhr/postgres_gateway/custom_types.clj
+++ b/src/clanhr/postgres_gateway/custom_types.clj
@@ -26,3 +26,6 @@
 
 (defmethod from-pg-value com.github.pgasync.impl.Oid/JSONB [oid value]
   (json/parse-string (String. value) true))
+
+(defmethod from-pg-value com.github.pgasync.impl.Oid/DATE [oid value]
+  (coerce/from-string (String. value)))


### PR DESCRIPTION
The new async driver introduced a bug. It would convert a DATE from
postgres to a datetime with local timezone adjustments. So day 10 would
become day 09 at 23h for example.

This patch intercepts the specific DATE load and converts it to a date
without timezone adjustments.
