### PR TITLE
Fix load numeric from datastore

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/postgres-gateway "1.8.1"
+(defproject clanhr/postgres-gateway "1.8.2"
   :description "ClanHR postgres-gateway"
   :url "https://github.com/clanhr/postgres-gateway"
 

--- a/src/clanhr/postgres_gateway/custom_types.clj
+++ b/src/clanhr/postgres_gateway/custom_types.clj
@@ -29,3 +29,6 @@
 
 (defmethod from-pg-value com.github.pgasync.impl.Oid/DATE [oid value]
   (coerce/from-string (String. value)))
+
+(defmethod from-pg-value com.github.pgasync.impl.Oid/NUMERIC [oid value]
+  (Double/parseDouble (String. value)))

--- a/test/clanhr/postgres_gateway/core_test.clj
+++ b/test/clanhr/postgres_gateway/core_test.clj
@@ -136,8 +136,8 @@
         (is (result/succeeded? result))
         (is (= 2 (count data)))))))
 
-#_(deftest inserting-with-exception
-  (let [result (<!! (core/save-model! {} {:table "does-not-exist"}))]
+(deftest inserting-with-exception
+  (let [result (<!! (core/save-model! {} {:table "does_not_exist"}))]
     (is (result/failed? result))))
 
 (deftest updating-non-existent

--- a/test/clanhr/postgres_gateway/core_test.clj
+++ b/test/clanhr/postgres_gateway/core_test.clj
@@ -26,6 +26,7 @@
                            id uuid primary key default uuid_generate_v4(),
                            model jsonb,
                            email varchar(200),
+                           num decimal,
                            updated_at timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP)")])))
 
 (defn- db-fixture [f]
@@ -271,5 +272,22 @@
 
     (is (result/succeeded? result))
     (is (= model-id (:_id result)))))
+
+(deftest query-decimals
+  (testing "saving data"
+    (let [email (str (str (java.util.UUID/randomUUID)) "@rupeal.com")
+        model-id (java.util.UUID/randomUUID)
+        model {:id model-id
+               :email email
+               :num 1.5
+               :updated_at (t/now)}
+        result (<!! (core/save-data! model {:table table}))]
+    (is (result/succeeded? result))
+    (testing "get-model"
+      (let [result (<!! (core/query-data [(str "select num from " table" where id = $1") model-id]
+                                         {:table table}))
+            data (first (:data result))]
+        (is (result/succeeded? result))
+        (is (= 1.5 (:num data))))))))
 
 #_(run-tests)


### PR DESCRIPTION
If a column had type NUMERIC we'd have an exception with: `Unknown
conversion source: NUMERIC`.

This patch adds a fn to convert those scenarios.
