### PR TITLE
Add changes to separate correctly the postgres array values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: clojure
 sudo: required
-lein: lein2
+lein: lein
 jdk:
   - oraclejdk8
 addons:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/postgres-gateway "1.12.0"
+(defproject clanhr/postgres-gateway "1.12.1"
   :description "ClanHR postgres-gateway"
   :url "https://github.com/clanhr/postgres-gateway"
 
@@ -26,4 +26,3 @@
 
   :source-paths ["src"]
   :test-paths ["test"])
-

--- a/test/clanhr/postgres_gateway/utils_test.clj
+++ b/test/clanhr/postgres_gateway/utils_test.clj
@@ -10,8 +10,12 @@
 
 (deftest array-column-types
   (is (nil? (utils/array-column-value nil)))
-  (is (= "{waza}" (utils/array-column-value "waza")))
-  (is (= "{waza,bi}" (utils/array-column-value ["waza" "bi"]))))
+  (is (= "{\"waza\"}" (utils/array-column-value "waza")))
+  (is (= "{\"waza\",\"bi\"}" (utils/array-column-value ["waza" "bi"])))
+  (is (= "{\"Kw, Lda.\",\"bi\"}" (utils/array-column-value ["Kw, Lda." "bi"])))
+  (is (= "{\"wa,za\",\"wa,bi\"}" (utils/array-column-value ["wa,za" "wa,bi"])))
+  (is (= "{\"wa, lda\",\"we,inc\",\"bi\"}" (utils/array-column-value "wa, lda§we,inc§bi")))
+  (is (= "{\"wa, lda\",\"bi\",\"wa,inc\"}" (utils/array-column-value "wa, lda§bi§wa,inc"))))
 
 (deftest like-value
   (is (= "" (utils/like-value nil)))
@@ -31,3 +35,12 @@
 
 (deftest lisp-case-keys
   (is (= {:some-key 1} (utils/->lisp-case-keys {:some_key 1}))))
+
+(deftest split-string
+  (is (= ["tag1", "tag2"] (#'utils/split-string "tag1,tag2")))
+  (is (= ["tag1", "tag2"] (#'utils/split-string "tag1§tag2")))
+  (is (= ["tag1, Lda.", "tag2"] (#'utils/split-string "tag1, Lda.§tag2"))))
+
+(deftest quote-string
+  (is (= "\"tag1\"" (#'utils/quote-string "tag1")))
+  (is (= "\"tag1\"" (#'utils/quote-string "\"tag1\""))))


### PR DESCRIPTION
* The tags are not being correctly saved in the reports database
* Now they will be saved with quotes do delimiter them, to escape commas
* Detect if the values are being separated using '§'
IE:
params: 
"KWAN, Lda., Rupeal, Rupeal, Lda." will convert to
{"KWAN, Lda.", "Rupeal", "Rupeal, Lda."} instead of {"KWAN", "Lda.", "Rupeal", "Rupeal", "Lda."}